### PR TITLE
Switch Travis-CI to Trusty release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-# Default OS image is Ubuntu 12.04 LTS Precise on Travis-CI for linux
+# Default OS image is Ubuntu 14.04 LTS Trusty on Travis-CI for linux
 language: c
+
+dist: trusty
 
 os:
   - linux
@@ -28,12 +30,12 @@ addons:
       - libperl-dev
       - python-dev
       - python3-dev
-      - liblua5.1-0-dev
-      - lua5.1
+      - liblua5.2-dev
+      - lua5.2
+      - ruby-dev
 
 before_install:
-    # make sure to use default 1.9.3 ruby (switching sudo on, does add different ruby versions, GRR!)
-  - rvm use 1.9.3 --install --binary --fuzzy
+  - rvm reset
 
 script:
   - NPROC=$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
Travis CI fails, because rvm cannot install ruby 1.9.3

Since we are using Ubuntu Precise (12.04), let's make the switch to Ubuntu 14.04

This should hopefully make it build again